### PR TITLE
Add: Prisma Integration for Product API and Price Field Type Update

### DIFF
--- a/prisma/migrations/20240309031701_update_product_price_to_float/migration.sql
+++ b/prisma/migrations/20240309031701_update_product_price_to_float/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `price` on the `product` table. The data in that column could be lost. The data in that column will be cast from `Int` to `Double`.
+
+*/
+-- AlterTable
+ALTER TABLE `product` MODIFY `price` DOUBLE NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,6 @@ model Product {
   id          Int    @id @default(autoincrement())
   name        String
   description String
-  price       Int
+  price       Float
   image       String
 }

--- a/src/app/api/products/route.tsx
+++ b/src/app/api/products/route.tsx
@@ -1,28 +1,13 @@
 import { NextRequest, NextResponse } from "next/server"
 
+import { prisma } from "@/prisma/client"
+
 import schema from "./schema"
 
-export function GET(request: NextRequest) {
-  //fetch products from db
-  return NextResponse.json(
-    [
-      {
-        id: 1,
-        name: "Product 1",
-        description: "Description 1",
-        price: 100,
-        image: "https://picsum.photos/200",
-      },
-      {
-        id: 2,
-        name: "Product 2",
-        description: "Description 2",
-        price: 200,
-        image: "https://picsum.photos/200",
-      },
-    ],
-    { status: 200 }
-  )
+export async function GET(request: NextRequest) {
+  const products = await prisma.product.findMany()
+
+  return NextResponse.json(products, { status: 200 })
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -31,8 +16,30 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!validation.success)
     return NextResponse.json(validation.error.errors, { status: 400 })
 
-  return NextResponse.json({ id: 10, ...body }, { status: 201 })
+  const newProduct = await prisma.product.create({
+    data: {
+      name: body.name,
+      price: body.price,
+      description: body.description,
+      image: body.image,
+    },
+  })
+
+  return NextResponse.json(newProduct, { status: 201 })
 }
+
+// export async function PUT(request: NextRequest): Promise<NextResponse> {
+//   const body = await request.json()
+//   const validation = schema.safeParse(body)
+//   if (!validation.success)
+//     return NextResponse.json(validation.error.errors, { status: 400 })
+
+//   return NextResponse.json({ id: 10, ...body })
+// }
+
+// export async function DELETE(request: NextRequest): Promise<NextResponse> {
+//   return NextResponse.json({ message: "Product deleted" })
+// }
 
 export async function PUT(request: NextRequest): Promise<NextResponse> {
   const body = await request.json()
@@ -40,10 +47,26 @@ export async function PUT(request: NextRequest): Promise<NextResponse> {
   if (!validation.success)
     return NextResponse.json(validation.error.errors, { status: 400 })
 
-  return NextResponse.json({ id: 10, ...body })
+  const updatedProduct = await prisma.product.update({
+    where: { id: body.id },
+    data: {
+      name: body.name,
+      price: body.price,
+      description: body.description,
+      image: body.image,
+    },
+  })
+
+  return NextResponse.json(updatedProduct, { status: 200 })
 }
 
-//DeLETe
 export async function DELETE(request: NextRequest): Promise<NextResponse> {
+  const body = await request.json()
+  const validation = schema.safeParse(body)
+  if (!validation.success)
+    return NextResponse.json(validation.error.errors, { status: 400 })
+
+  await prisma.product.delete({ where: { id: body.id } })
+
   return NextResponse.json({ message: "Product deleted" })
 }


### PR DESCRIPTION
# Prisma Integration for Product API and Price Field Type Update

## Key Changes

- **Prisma Integration**: Refactored the product-related API endpoints to use Prisma. This includes fetching all products in the `GET` request, creating a new product in the `POST` request, updating a product in the `PUT` request, and deleting a product in the `DELETE` request.

- **Price Field Update**: Updated the `price` field for the product from an integer to a floating-point number to accommodate a wider range of prices.

## Motivation

The update brings our product management system in line with the rest of our Prisma-backed services. Utilizing Prisma for our product API endpoints allows for direct interaction with our database, ensuring consistency and reliability in our data operations. 

Changing the `price` field from `Int` to `Float` allows us to accurately represent prices that have decimals, providing a more precise and flexible pricing structure. 


